### PR TITLE
Increase DMOD stack size from 1024 to 2048

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if(NOT DMELL_BUILD_TESTS)
     set(DMOD_AUTHOR_NAME        Patryk Kubiak)
 
     # Stack size for the module (should be integer)
-    set(DMOD_STACK_SIZE         1024)
+    set(DMOD_STACK_SIZE         2048)
 
     #
     #   dmod_add_library - create a library module


### PR DESCRIPTION
This pull request makes a small change to the stack size configuration in the `CMakeLists.txt` file, doubling the value from 1024 to 2048. This adjustment will allow modules to use more stack memory during execution.